### PR TITLE
Avoid using control chars in router name.

### DIFF
--- a/nuage_neutron/plugins/common/service_plugins/l3.py
+++ b/nuage_neutron/plugins/common/service_plugins/l3.py
@@ -14,6 +14,8 @@
 
 import copy
 from logging import handlers
+import re
+
 import netaddr
 from oslo_config import cfg
 from oslo_log.formatters import ContextFormatter
@@ -82,6 +84,12 @@ class NuageL3Plugin(base_plugin.BaseNuagePlugin,
 
     def get_plugin_description(self):
         return "Plugin providing support for routers and floatingips."
+
+    @staticmethod
+    def _is_resource_name_ok(name):
+        if re.search(r'[\a,\b,\f,\n,\r,\t,\v]', name) is None:
+            return True
+        return False
 
     def init_fip_rate_log(self):
         self.def_fip_rate = cfg.CONF.FIPRATE.default_fip_rate
@@ -638,6 +646,11 @@ class NuageL3Plugin(base_plugin.BaseNuagePlugin,
     @db.retry_if_session_inactive()
     @log_helpers.log_method_call
     def create_router(self, context, router):
+        if 'name' in router['router']:
+            if not self._is_resource_name_ok(router['router']['name']):
+                msg = _('router name contains invalid characters.')
+                raise nuage_exc.NuageBadRequest(msg=msg)
+
         routing_mechanisms.update_routing_values(router['router'])
 
         req_router = copy.deepcopy(router['router'])
@@ -691,6 +704,11 @@ class NuageL3Plugin(base_plugin.BaseNuagePlugin,
     @log_helpers.log_method_call
     def update_router(self, context, id, router):
         updates = router['router']
+        if 'name' in updates:
+            if not self._is_resource_name_ok(updates['name']):
+                msg = _('router name contains invalid characters.')
+                raise nuage_exc.NuageBadRequest(msg=msg)
+
         original_router = self.get_router(context, id)
         self._validate_update_router(context, id, updates)
         routing_mechanisms.update_routing_values(updates, original_router)


### PR DESCRIPTION
OpenStack resource names have no restrictions, allow all utf8
characters, even if they are control characters.
However, Nuage cannot accept some control characters (e.g. '\v').
So, this fix will avoid create/update router, if the name contains
those invalid ones.