### PR TITLE
add support for vnic_type portbindings.VNIC_VIRTIO_FORWARDER

### DIFF
--- a/nuage_neutron/plugins/nuage_ml2/mech_nuage.py
+++ b/nuage_neutron/plugins/nuage_ml2/mech_nuage.py
@@ -2254,7 +2254,8 @@ class NuageMechanismDriver(base_plugin.RootNuagePlugin,
     @staticmethod
     def _supported_vnic_types():
         return [portbindings.VNIC_NORMAL,
-                portbindings.VNIC_DIRECT]
+                portbindings.VNIC_DIRECT,
+                portbindings.VNIC_VIRTIO_FORWARDER]
 
     @staticmethod
     def _direct_vnic_supported(port):


### PR DESCRIPTION
This patch allow to bind virto-forwarder port. It required
the following changes in nova [1] and os-vif and [2]
and the containerized-ovs-forwarder to be deployed [3]

[1] - https://github.com/Mellanox/containerized-ovs-forwarder/blob/master/openstack/ovs-kernel/nova_os_vif_util.patch
[2] - https://github.com/Mellanox/containerized-ovs-forwarder/blob/master/openstack/ovs-kernel/os-vif.patch
[3] - https://github.com/Mellanox/containerized-ovs-forwarder/blob/master/container_create.sh